### PR TITLE
docs/criando-documentacao-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+## Projeto PlantCare "Cuidado com Plantas" - 2º Período IPI
+
+![HTML](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)
+![CSS](https://img.shields.io/badge/CSS3-1572B6?style=for-the-badge&logo=css3&logoColor=white)
+![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)
+![PHP](https://img.shields.io/badge/PHP-777BB4?style=for-the-badge&logo=php&logoColor=white)
+
+> Repositório do PlantCare
+### Documentação
+
+### 🔥 Patch Notes - V1.0.0 24/07/2025
+
+Histórico de atualizações:
+
+|   Versão      |           Detalhes            |
+|---------------|-------------------------------|
+|    `v1.0.0`      |    - Criação do catálogo de plantas, filtro por categoria e redes sociais.
+
+## 📝 Fluxo de desenvolvimento
+
+Para contribuir com o **PlantCare**, siga estas etapas:
+
+1. Acesse a branch `main`.
+2. Crie um branch: `git checkout -b <nome_branch>`. Obs: É interessante criar uma branch com nome que refira as ativades que serão realizadas, evitar commitar diretamente na main ou criar branchs com nomes genéricos como:
+    - "correção de bugs"
+    - "Inserindo coisas novas"
+    - "Fazendo alterações"
+
+    Utilize nomes que atendam aos Conventional Commits e descritivos como:
+    - "feat/adicionando-login"
+    - "fix/corrigindo-erro-da-barra-de-hp"
+    - "docs/documentando-descrição-da-readme"
+
+3. Faça suas alterações e confirme-as: `git commit -m '<mensagem_commit>'`
+4. Suba a branch com as modificações: `git push origin <nome_branch>`
+5. Crie a solicitação de merge. Dessa forma mantemos um histórico do que foi implementado.
+
+Como alternativa, consulte a documentação do GitHub em [como criar um merge request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request).
+
+Para consulta a respeito dos [Conventional Commmits](https://www.conventionalcommits.org/en/v1.0.0/)


### PR DESCRIPTION
- Documentei o readme para gerar uma padronização de commits no projeto
- Adicionei junto a isso um patch notes, para tentarmos manter "backups" de versões (branchs) estáveis do projeto já que atualmente fazemos tudo na main e talvez isso possa gerar algum problema caso algum commit quebre o código.
- Adicionei links de referência sobre o que foi feito.